### PR TITLE
Changes In both the Chrome and Firefox imports:

### DIFF
--- a/Projects/tabbed_bookmarks_manager/tabbed_bookmarks_manager.leo
+++ b/Projects/tabbed_bookmarks_manager/tabbed_bookmarks_manager.leo
@@ -2463,7 +2463,7 @@ def walk(root, folders):
                 pu = fol.insertAsLastChild()
                 date = gnx2date(pu.v.gnx)
                 pu.h = name
-                pu.b = f':title: {name}\n:ref:{url}\n:added:{date}'
+                pu.b = f':title: {name}\n:ref: {url}\n:date-added: {date}'
             walk(fol, folder_list)
 
 target = create_head_node('@bookmark-collection')
@@ -2550,7 +2550,7 @@ def walk(root, folders):
                 pu = fol.insertAsLastChild()
                 date = gnx2date(pu.v.gnx)
                 pu.h = name
-                pu.b = f':title: {name}\n:ref:{url}\n:added:{date}'
+                pu.b = f':title: {name}\n:ref: {url}\n:date-added: {date}'
             walk(fol, folder_list)
 
 target = create_head_node('@bookmark-collection')


### PR DESCRIPTION
1) Add a space after ":ref:".  Your "search" code expects a space after ":ref:" I think it is likely that when you wrote and used the import code, you didn't want the space, but later you added a space and failed to update the imports.

2) Change ":added:" to "date-added: "
Same reasoning as 1)