### PR TITLE
On Windows, start console in directory of current external file 

### DIFF
--- a/Projects/TomPassinScripts.leo
+++ b/Projects/TomPassinScripts.leo
@@ -330,7 +330,7 @@ direc = osp.normpath(direc)
 
 if g.os_path_exists(direc):
     if g.isWindows:
-        cmd = 'start cmd.exe'
+        cmd = f'start cmd.exe /K "cd {direc}"'
         run(cmd, shell=True)
     else:
         cmd = 'x-terminal-emulator'


### PR DESCRIPTION
(previously, would start in directory of the outline even if an external file had been selected).